### PR TITLE
Fix build failure if the project file is in a folder containing blanks

### DIFF
--- a/FRHED/PreLink.bat
+++ b/FRHED/PreLink.bat
@@ -6,8 +6,8 @@ cd ..\Translations\Frhed
 cscript CreateMasterPotFile.vbs
 cscript UpdatePoFilesFromPotFile.vbs
 cd ..\..\FRHED
-rc /fo%~1\lang.res /i.. ..\Translations\Frhed\heksedit.rc
-mkdir %~2\..\Languages
-link /DLL /NOENTRY /MACHINE:IX86 /OUT:%~2\..\Languages\heksedit.lng %~1\lang.res
-editbin.exe /OSVERSION:4.0 /SUBSYSTEM:WINDOWS,4.0 %2\..\Languages\heksedit.lng
-copy ..\Translations\Frhed\*.po %2\..\Languages
+rc "/fo%~1\lang.res" /i.. ..\Translations\Frhed\heksedit.rc
+mkdir "%~2\..\Languages"
+link /DLL /NOENTRY /MACHINE:IX86 "/OUT:%~2\..\Languages\heksedit.lng" "%~1\lang.res"
+editbin.exe /OSVERSION:4.0 /SUBSYSTEM:WINDOWS,4.0 "%~2\..\Languages\heksedit.lng"
+copy ..\Translations\Frhed\*.po "%~2\..\Languages"


### PR DESCRIPTION
This PR fixes build failure if the project file is in a folder with a folder name containing blanks
related to https://github.com/WinMerge/winmerge/issues/841#issuecomment-867846001
